### PR TITLE
first attempt to fix PC sign issue

### DIFF
--- a/R/proc_index.R
+++ b/R/proc_index.R
@@ -13,6 +13,13 @@ proc_index <- function(keywords, geo, index_name) {
     select(-id) %>%
     ts_scale()
 
+  # determine PC sign based on average correlation with actual time series
+  values  <- mapply(getElement, split(data, data$keyword), "value")
+  corsign <- mean(cor(values, x_prcomp$value))
+  if(corsign < 0) {
+    x_prcom$value <- -x_prcomp$value
+  }
+
   # invert main index
   if (index_name == "trendecon") {
     x_prcomp$value <- -x_prcomp$value

--- a/R/proc_index.R
+++ b/R/proc_index.R
@@ -17,7 +17,7 @@ proc_index <- function(keywords, geo, index_name) {
   values  <- mapply(getElement, split(data, data$keyword), "value")
   corsign <- mean(cor(values, x_prcomp$value))
   if(corsign < 0) {
-    x_prcom$value <- -x_prcomp$value
+    x_prcomp$value <- -x_prcomp$value
   }
 
   # invert main index


### PR DESCRIPTION
Attempt to fix PC sign instability by checking if principal component correlates positively with the actual time series data. In the case of negative correlation the PC scores are reversed.