### PR TITLE
fixing issue #62

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,4 +38,4 @@ URL: https://www.trendecon.org
 BugReports: https://github.com/trendecon/trendecon/issues
 VignetteBuilder: knitr
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: trendecon
 Title: Create Daily Series from Google Trends
-Version: 0.2.1
+Version: 0.2.2
 Authors@R: c(
     person("Angelica", "Becerra", role = "aut"),
     person("Nina", "Mühlebach", role = "aut"),

--- a/R/proc_keyword_init.R
+++ b/R/proc_keyword_init.R
@@ -42,7 +42,8 @@ proc_keyword_init <- function(keyword = "Insolvenz",
     keyword = keyword,
     geo = geo,
     from = from, stepsize = "15 days", windowsize = "6 months",
-    n_windows = 348, wait = 20, retry = 10,
+    n_windows = floor(as.numeric(Sys.Date() - as.Date(from)) / 15),
+    wait = 20, retry = 10,
     prevent_window_shrinkage = TRUE
   )
 
@@ -56,7 +57,8 @@ proc_keyword_init <- function(keyword = "Insolvenz",
     keyword = keyword,
     geo = geo,
     from = from, stepsize = "11 weeks", windowsize = "5 years",
-    n_windows = 68, wait = 20, retry = 10,
+    n_windows = floor(as.numeric(Sys.Date() - as.Date(from)) / (11 * 7)),
+    wait = 20, retry = 10,
     prevent_window_shrinkage = TRUE
   )
   if (indicator_raw) write_csv(w, path_draws(tolower(geo), paste0(keyword, "_w.csv")))
@@ -67,7 +69,8 @@ proc_keyword_init <- function(keyword = "Insolvenz",
     keyword = keyword,
     geo = geo,
     from = from, stepsize = "1 month", windowsize = "15 years",
-    n_windows = 12, wait = 20, retry = 10,
+    n_windows = ceiling(as.numeric(Sys.Date() - as.Date(from)) / (15 * 365) * 12),
+    wait = 20, retry = 10,
     prevent_window_shrinkage = FALSE
   )
   if (indicator_raw) write_csv(m, path_draws(tolower(geo), paste0(keyword, "_m.csv")))

--- a/R/ts_gtrends_mwd.R
+++ b/R/ts_gtrends_mwd.R
@@ -18,7 +18,8 @@ ts_gtrends_mwd <- function(keyword = "Insolvenz", geo = "CH") {
     keyword = keyword,
     geo = geo,
     from = from, stepsize = "15 days", windowsize = "6 months",
-    n_windows = 348, wait = 20, retry = 10,
+    n_windows = floor(as.numeric(Sys.Date() - as.Date(from)) / 15),
+    wait = 20, retry = 10,
     prevent_window_shrinkage = TRUE
   )
   d2 <- ts_gtrends_windows(
@@ -31,20 +32,21 @@ ts_gtrends_mwd <- function(keyword = "Insolvenz", geo = "CH") {
   )
   dd <- aggregate_averages(aggregate_windows(d), aggregate_windows(d2))
 
-  # download weakly series
+  # download weekly series
   w <- ts_gtrends_windows(
     keyword = keyword,
     geo = geo,
     from = from, stepsize = "11 weeks", windowsize = "5 years",
-    n_windows = 68, wait = 20, retry = 10,
+    n_windows = floor(as.numeric(Sys.Date() - as.Date(from)) / (11 * 7)),
+    wait = 20, retry = 10,
     prevent_window_shrinkage = TRUE
   )
   w2 <- ts_gtrends_windows(
     keyword = keyword,
     geo = geo,
-    from = seq(Sys.Date(), length.out = 2, by = "-1 year")[2],
-    stepsize = "1 week", windowsize = "1 year",
-    n_windows = 12, wait = 20, retry = 10,
+    from = seq(Sys.Date(), length.out = 2, by = "-2 year")[2],
+    stepsize = "1 week", windowsize = "2 year",
+    n_windows = 24, wait = 20, retry = 10,
     prevent_window_shrinkage = FALSE
   )
   ww <- aggregate_averages(aggregate_windows(w), aggregate_windows(w2))
@@ -54,7 +56,8 @@ ts_gtrends_mwd <- function(keyword = "Insolvenz", geo = "CH") {
     keyword = keyword,
     geo = geo,
     from = from, stepsize = "1 month", windowsize = "15 years",
-    n_windows = 12, wait = 20, retry = 10,
+    n_windows = ceiling(as.numeric(Sys.Date() - as.Date(from)) / (15 * 365) * 12),
+    wait = 20, retry = 10,
     prevent_window_shrinkage = FALSE
   )
   m2 <- ts_gtrends_windows(


### PR DESCRIPTION
@christophsax one proposal to fix issue #62 .

For now this change is only in `ts_gtrends_mwd()` - but the same applies to `proc_keyword_init()`. Only pushing this fix for review, if approved then I can also modify `proc_keywod_init()`. After both places are adjusted this should close 3 open issues at once.

The original decision to have `n_window` argument gets in the way here a bit. IMO it would be more logical for `ts_gtrends_windows` to accept `from`, `to`, and `stepsize`, instead of `from`, `to`, and `n_windows` as it currently does. But such a change would be riskier.

Waiting for your comments / approval.