### PR TITLE
skipping seasonal adjustment when geo = ''

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: trendecon
 Title: Create Daily Series from Google Trends
-Version: 0.2.4
+Version: 0.2.5
 Authors@R: c(
     person("Angelica", "Becerra", role = "aut"),
     person("Nina", "Mühlebach", role = "aut"),
@@ -39,4 +39,4 @@ URL: https://www.trendecon.org
 BugReports: https://github.com/trendecon/trendecon/issues
 VignetteBuilder: knitr
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.0
+RoxygenNote: 7.2.1

--- a/R/proc_seas_adj.R
+++ b/R/proc_seas_adj.R
@@ -2,6 +2,11 @@
 #
 # seas_adj_file("Insolvenz")
 proc_seas_adj <- function(keyword = "Insolvenz", geo = "ch") {
+  if (geo == "") {
+    message("skipping seasonal adjustment: can only be performed on a per-country basis.")
+    return(TRUE)
+  }
+
   message("seasonal adjustment keyword: ", keyword)
 
   tsbox::load_suggested("prophet")


### PR DESCRIPTION
Fixing the error in #82 

Proposed solution - skip seasonal adjustment when `geo = ""` and inform the user with a message.

Before:

    extend daily data by hourly data for the missing recent days
    align daily data to weekly
    align weekly data to monthly
    seasonal adjustment keyword: helium

    Error in prophet::add_country_holidays(., country_name = toupper(geo)):
    Holidays in  are not currently supported!

After:

    extend daily data by hourly data for the missing recent days
    align daily data to weekly
    align weekly data to monthly

    skipping seasonal adjustment: can only be performed on a per-country basis.