### PR TITLE
made downloading robust against server responses 500 and 429

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: trendecon
 Title: Create Daily Series from Google Trends
-Version: 0.2.5
+Version: 0.2.6
 Authors@R: c(
     person("Angelica", "Becerra", role = "aut"),
     person("Nina", "Mühlebach", role = "aut"),

--- a/R/gtrends_with_backoff.R
+++ b/R/gtrends_with_backoff.R
@@ -35,44 +35,39 @@ gtrends_with_backoff <- function(keyword = NA,
       tz = tz, onlyInterest = onlyInterest
     ),
     error = function(e) {
-      if (grepl("== 200", e)) {
-        if (attempt == 1) {
-          msg("Oh noes, they don't like us anymore...")
-        } else {
-          msg("Nope, still nothing...")
-        }
-
-        t <- attempt * wait
-
-        # Exponential backoff. Neat but not really suitable here.
-        # t <- wait*ceiling(runif(1)*(2^attempt-1))
-
-        msg("Waiting for ", t, " seconds")
-        Sys.sleep(t)
-        msg("Retrying...")
-
-        # Error handling by recurshian... xD
-        # TODO: Could replace this with a while(attemt < retry && !is.tibble(result)) { result <- tryCatch(call, error = function(e) FALSE)}
-        # construct. easier on the stack if retry gets large
-        gtrends_with_backoff(
-          keyword,
-          geo,
-          time,
-          gprop,
-          category,
-          hl,
-          low_search_volume,
-          cookie_url,
-          tz,
-          onlyInterest,
-          retry,
-          wait,
-          quiet,
-          attempt + 1
-        )
+      if (grepl("== 200 is not TRUE", e)) {
+        msg("Server is not accepting requests")
+      } else if (grepl("code\\:429", e)) {
+        msg("Server response: 429 - too many requests")
+      } else if (grepl("code\\:500", e)) {
+        msg("Server response: 500 - internal server error")
       } else {
         stop(e)
       }
+
+      t <- attempt * wait
+
+      msg("Waiting for ", t, " seconds")
+      Sys.sleep(t)
+      msg("Retrying...")
+
+      # Error handling by recursion
+      gtrends_with_backoff(
+        keyword,
+        geo,
+        time,
+        gprop,
+        category,
+        hl,
+        low_search_volume,
+        cookie_url,
+        tz,
+        onlyInterest,
+        retry,
+        wait,
+        quiet,
+        attempt + 1
+      )
     }
   )
 }


### PR DESCRIPTION
Hello Christoph,

Finally I caught the error reported by #81 on my end.

Turns out sometimes `gtrends` package returns the error as `response == 200 is not TRUE`, while other times it returns `status code: 429`. Not sure what this depends on, but we were only retrying in case of the first response. Now I made it robust against 3 different scenarios: original response, 429 response, and in addition 500 response.

Here is how it looks:

![Screenshot 2022-07-26 at 11 30 58 PM](https://user-images.githubusercontent.com/7273684/181106948-98875543-1e8b-4b20-bf65-af90d57e0976.png)

And:

![Screenshot 2022-07-26 at 11 28 38 PM](https://user-images.githubusercontent.com/7273684/181106974-bc4b3305-098e-4fdc-a485-f91d5dd7c6c0.png)